### PR TITLE
Support selection from multiple lists

### DIFF
--- a/src/js/common.js
+++ b/src/js/common.js
@@ -14,7 +14,7 @@ function initializeStartupConfiguration() {
         "proteinDomainName" : [],
         "diseaseName" : [],
         "organism" : [],
-        "savedList": null
+        "savedList": []
     }; // 0 = GO annotation, 1 = Dataset Name, 2 = Pathway Name, 3 = Protein Domain Name, 4 = Disease Name
 
     window.interminesHashMap = null;
@@ -23,6 +23,7 @@ function initializeStartupConfiguration() {
     window.clinVarFilter = null;
     window.expressionFilter = null;
     window.organismFilterLetters = ["A","B","C","D","E","F","G","H","I","J"];
+    window.constraintCodes = ["N","O","P","Q","R","S","T","U","V","W","X","Y","Z"];
     window.organismFilter = null;
     window.organismColorsMap = {}
     window.proteinLocalisationFilter = null;
@@ -194,8 +195,8 @@ function initializeSavedLists(){
             $("#listManagerModal").modal("hide");
         });
         $("#listManagerResetButton").click(function() {
-            if(window.imTableConstraint['savedList']) {
-                window.imTableConstraint['savedList'] = null;
+            if(window.imTableConstraint['savedList'].length) {
+                window.imTableConstraint['savedList'] = [];
                 $('.saved-list-item').each(function(i, el_) {
                     el_.dataset.listConstraintActive = "false";
                     el_.classList.remove('active');
@@ -209,17 +210,15 @@ function initializeSavedLists(){
                 if(el.dataset.listConstraintActive === "true") {
                     el.dataset.listConstraintActive = "false";
                     el.classList.remove('active');
-                    window.imTableConstraint["savedList"] = null;
+                    window.imTableConstraint["savedList"] = window.imTableConstraint[
+                      "savedList"
+                    ].filter(title => title !== el.textContent);
                 }
                 else {
-                    $('.saved-list-item').each(function(i, el_) {
-                        el_.dataset.listConstraintActive = "false";
-                        el_.classList.remove('active');
-                    });
                     el.dataset.listConstraintActive = "true";
                     el.classList.add('active');
                     var listName = el.textContent;
-                    window.imTableConstraint['savedList'] = listName;
+                    window.imTableConstraint['savedList'].push(listName)
                 }
             });
         });
@@ -340,12 +339,17 @@ function updateTableWithConstraints() {
 
     // List Constraints
     if(window.imTableConstraint['savedList']) {
-        window.imTable.query.addConstraint({
-            "path": sessionStorage.getItem('currentClassView'),
+       const path = sessionStorage.getItem('currentClassView')
+       const constraints = window.imTableConstraint['savedList'].map((list, idx) => {
+         return {
+            path,
             "op": "IN",
-            "value": window.imTableConstraint["savedList"],
-            "code": "N"
-        });
+            "value": list,
+            "code": window.constraintCodes[idx]
+         }
+       })
+       
+       window.imTable.query.addConstraints(constraints);  
     }
 
     window.imTable.query.constraintLogic = window.tableConstraintLogic;

--- a/src/js/common.js
+++ b/src/js/common.js
@@ -213,8 +213,9 @@ function initializeSavedLists(){
                     window.imTableConstraint["savedList"] = window.imTableConstraint[
                       "savedList"
                     ].filter(title => title !== el.textContent);
-                }
-                else {
+                } else if(window.imTableConstraint['savedList'].length === 13) {
+                    window.alert('You can only select a max of 13 List Contraints')
+                } else {
                     el.dataset.listConstraintActive = "true";
                     el.classList.add('active');
                     var listName = el.textContent;


### PR DESCRIPTION
## Description
This PR attempts to resolve #32, which would allow the user to select multiple lists from the Gene/Protein intermine lists.

I've managed to add multiple lists to the query using `window.imTable.query.addConstraints` which allows me to pass in an array of contraints.

I stepped through the debugger and for the most part it returns a result from the server, until it tries to parse the xml. Then I run into the error below. I truncated the `view` and `constraintLogic` so the code fits without scrolling.

```xml
"Error: XML is not well formatted. Got 
<query model="genomic" view="Gene.symbol Gene.name..." constraintLogic="(A OR B..." >
  <constraint path="Gene" op="IN" value="PL_BHF_UCL_cardiovascGenes" code="N" />
  <constraint path="Gene" op="IN" value="PL_DiabesityGWAS_pval-4" code="N" />
</query>
```

Yet when I try running the query on the humanMine website, I get this xml structure:

```xml
<query model="genomic" view="Gene.name Gene.symbol..." constraintLogic="A and B">
  <constraint path="Gene" op="IN" value="PL_BHF_UCL_cardiovascGenes" code="B" />
  <constraint path="Gene" op="IN" value="PL_DiabesityGWAS_pval-4" code="A"/>
</query>
```

This seems well formatted to me, so I'm at a loss as to what the error means. 

The stack trace throws inside the `es6-promise` package used by `imTables`. The last method called that belongs to the `imTables` library is `Service.prototype.authorise` (I'm tracing through the compiled package).

I have no idea where to go from here. Any thoughts?

## Related issues and discussion
#32 

## Screenshots, if any
Stack trace:
![Screen Shot 2020-03-09 at 20 39 05](https://user-images.githubusercontent.com/24993360/76268894-16531d80-6246-11ea-994e-c42886ca448e.png)


## Checklist
Please make sure these boxes are checked before submitting your pull request - thanks!

- [x] Run the tests
