### PR TITLE
Fix x button which shown on the filters input fields

### DIFF
--- a/src/js/common.js
+++ b/src/js/common.js
@@ -773,6 +773,7 @@ function addCustomFilters() {
                                 remove(window.imTableConstraint["diseaseName"], ui.item.value);
                                 updateTableWithConstraints();
                                 $("#" + ui.item.value.replace(/[^a-zA-Z0-9]/g, '')).remove();
+								$("#diseasesSearchInput").val("");
                             });
                         },
                         focus: function(event, ui) {
@@ -1089,6 +1090,7 @@ function addCustomFilters() {
                                 remove(window.imTableConstraint["proteinDomainName"], ui.item.value);
                                 updateTableWithConstraints();
                                 $("#" + ui.item.value.replace(/[^a-zA-Z0-9]/g, '')).remove();
+								$("#proteinDomainNameSearchInput").val("");
                             });
                         },
                         focus: function(event, ui) {
@@ -1147,6 +1149,7 @@ function addCustomFilters() {
                                        remove(window.imTableConstraint["phenotypeName"], ui.item.value);
                                        updateTableWithConstraints();
                                        $("#" + ui.item.value.replace(/[^a-zA-Z0-9]/g, '')).remove();
+									   $("#phenotypeNameSearchInput").val("");
                                    });
                                },
                                focus: function(event, ui) {
@@ -1461,6 +1464,7 @@ function createGoAnnotationFilter() {
                         remove(window.imTableConstraint["goAnnotation"], ui.item.value);
                         updateTableWithConstraints();
                         $("#" + ui.item.value.replace(/[^a-zA-Z0-9]/g, '')).remove();
+						$("#goAnnotationSearchInput").val("");
                     });
                 },
                 focus: function(event, ui) {
@@ -1583,6 +1587,7 @@ function createPathwaysNameFilter() {
                         remove(window.imTableConstraint["pathwayName"], ui.item.value);
                         updateTableWithConstraints();
                         $("#" + ui.item.value.replace(/[^a-zA-Z0-9]/g, '')).remove();
+						$("#pathwayNameSearchInput").val("");
                     });
                 },
                 focus: function(event, ui) {


### PR DESCRIPTION
## Description
when the user use one of the filters (e.g: Pathway Name filter) and select one of the filter options, the X button is shown, and if the user click the button, it will reset the view and the table content, but the value of the input text is not cleared, I think since the view is cleared on the button press, then the input text value should be cleared also.
I reset the value of each one of the filters input fields using $("#filter_id").val("");
for each filter on the point when the whole view is get reset by the x button click.

## Related issues and discussion
#94 

